### PR TITLE
Add support for `carrierwave` 1.0.x

### DIFF
--- a/carrierwave-imageoptim.gemspec
+++ b/carrierwave-imageoptim.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "carrierwave", ["~> 0.10"]
+  spec.add_dependency "carrierwave", ">= 0.10", "< 1.1"
   spec.add_runtime_dependency 'image_optim', '~> 0.22'
 
   spec.add_development_dependency "bundler", "~> 1.10"


### PR DESCRIPTION
This relaxes the version constraint to allow support for `carrierwave` version 1.0.x which was recently released.